### PR TITLE
fix(action_mysql): Change MySQL timeout to 30s

### DIFF
--- a/pkg/plugins/mysql/base.go
+++ b/pkg/plugins/mysql/base.go
@@ -49,7 +49,7 @@ func (m *MySQLConnector) getConnectionWithOptions(resourceOptions map[string]int
 func (m *MySQLConnector) connectPure() (db *sql.DB, err error) {
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", m.Resource.DatabaseUsername,
 		m.Resource.DatabasePassword, m.Resource.Host, m.Resource.Port, m.Resource.DatabaseName)
-	db, err = sql.Open("mysql", dsn+"?timeout=5s")
+	db, err = sql.Open("mysql", dsn+"?timeout=30s")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

This PR changes MySQL action timeout setting to 30s

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
-->

## Tested?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
